### PR TITLE
Add all platforms to travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: generic
 sudo: required
 dist: trusty
 compiler: gcc
@@ -11,19 +11,27 @@ branches:
 env:
 - PLATFORM=appliance
 - PLATFORM=genericx86-64
+- PLATFORM=as5712
+- PLATFORM=as6712
+- PLATFORM=as7512
+- PLATFORM=as7712
+- PLATFORM=mlnx-sn2xxx
+  # these are missing opennsl
+  #- PLATFORM=as5812t
+  #- PLATFORM=as5812x
 
 addons:
   ssh_known_hosts: yocto.libreswitch.org
 
 before_install:
 - sudo apt-get update -qq
-- sudo apt-get install -qq gawk wget git-core diffstat unzip texinfo build-essential
-  chrpath screen curl device-tree-compiler
+- sudo apt-get install -qq gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath screen curl device-tree-compiler libsdl1.2-dev xterm libfontconfig1
+- sudo apt-get autoremove
 install: true
 
 script:
 - make configure $PLATFORM
-- make
+- travis_wait 50 make
 
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_2b923ab06c69_key -iv $encrypted_2b923ab06c69_iv


### PR DESCRIPTION
Few things changed:
- switch to language:generic to decrease travis image size.
- use travis_wait not to fail on timeout.
- add all platforms except for those that missing opennsl packages.

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>