### PR TITLE
Fix openxps build with kernel 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ env:
 - PLATFORM=as5712
 - PLATFORM=as6712
 - PLATFORM=as7712
+- PLATFORM=as7512
 #currently broken due compiler flags
-#- PLATFORM=as7512
 #- PLATFORM=mlnx-sn2xxx
 # these are missing opennsl
 #- PLATFORM=as5812t

--- a/yocto/libreswitch/meta-distro-libreswitch/recipes-asic/xpliant/files/Replace-strnicmp-with-strncasecmp.patch
+++ b/yocto/libreswitch/meta-distro-libreswitch/recipes-asic/xpliant/files/Replace-strnicmp-with-strncasecmp.patch
@@ -1,0 +1,36 @@
+From 2326240f41be92310aecaa9048b7de5292d484d4 Mon Sep 17 00:00:00 2001
+From: Rosario Contarino <contarino.rosario@gmail.com>
+Date: Mon, 23 Jan 2017 14:44:49 +0100
+Subject: [PATCH] Replace strnicmp with strncasecmp.
+
+This commit replaces `strnicmp` with `strncasecmp` because the former was
+removed in Linux kernel 4.0
+---
+ xpnet/src/xp_pcie_slave.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xpnet/src/xp_pcie_slave.c b/xpnet/src/xp_pcie_slave.c
+index 9638fa1..a645a7e 100644
+--- a/xpnet/src/xp_pcie_slave.c
++++ b/xpnet/src/xp_pcie_slave.c
+@@ -444,7 +444,7 @@ static int xpreg_seq_show(struct seq_file *sf, void *v)
+     xp_private_t *xp_reg_priv = NULL;
+     xp_reg_priv = sf->private;
+   
+-    if (!strnicmp(xp_reg_priv->reg_rw_status, NAME_STR_HELP, sizeof(NAME_STR_HELP) - 1)) {
++    if (!strncasecmp(xp_reg_priv->reg_rw_status, NAME_STR_HELP, sizeof(NAME_STR_HELP) - 1)) {
+        reg_procfs_help(sf, MINOR(xp_reg_priv->cdev.dev));
+     } else if(strlen(xp_reg_priv->reg_rw_status) < 1) {
+        seq_printf(sf, "Invalid input. Please find help as below..");
+@@ -520,7 +520,7 @@ static ssize_t xpreg_proc_write(struct file *filp, const char *buf,
+                           "Read register = 0x%x value = 0x%x\n",reg_index,
+                           reg_value);
+              }
+-        } else if(!strnicmp(buf, NAME_STR_HELP, sizeof(NAME_STR_HELP) - 1)) {
++        } else if(!strncasecmp(buf, NAME_STR_HELP, sizeof(NAME_STR_HELP) - 1)) {
+                 snprintf(xp_reg_priv->reg_rw_status,
+                          sizeof(xp_reg_priv->reg_rw_status) - 1,
+                          "%s", NAME_STR_HELP);
+-- 
+1.8.3.1
+

--- a/yocto/libreswitch/meta-distro-libreswitch/recipes-asic/xpliant/xpliant-openxps.bb
+++ b/yocto/libreswitch/meta-distro-libreswitch/recipes-asic/xpliant/xpliant-openxps.bb
@@ -9,7 +9,9 @@ DEPENDS = "libxml2 libpcap lmsensors"
 
 RDEPENDS_${PN} = "libpcap python-doctest"
 
-SRC_URI = "git://github.com/xpliant/OpenXPS;protocol=http"
+SRC_URI = "git://github.com/xpliant/OpenXPS;protocol=http \
+           file://Replace-strnicmp-with-strncasecmp.patch \
+          "
 
 SRCREV = "a6b856f2faa5b2325d9774ebf4d5efc48067179f"
 


### PR DESCRIPTION
This commit replaces `strnicmp` with `strncasecmp` in the xpliant-openxps
sources. This is necessary to compile the drivers against the Linux kernel 4.0
and later.