### PR TITLE
Take opennsl binaries from libreswitch.org.

### DIFF
--- a/yocto/libreswitch/meta-distro-libreswitch/recipes-asic/opennsl/opennsl-cdp_3.2.0.1.bb
+++ b/yocto/libreswitch/meta-distro-libreswitch/recipes-asic/opennsl/opennsl-cdp_3.2.0.1.bb
@@ -11,7 +11,7 @@ OPENNSL_PLATFORM ?= "undefined"
 OPENNSL_PLATFORM_BUILD ?= "unknown"
 GPL_MODULES_DIR ?= "undefined"
 
-SRC_URI = "https://archive.openswitch.net/opennsl/opennsl-${PV}-cdp-${OPENNSL_PLATFORM}-${OPENNSL_PLATFORM_BUILD}.tar.bz2 \
+SRC_URI = "https://libreswitch.org/opennsl/opennsl-${PV}-cdp-${OPENNSL_PLATFORM}-${OPENNSL_PLATFORM_BUILD}.tar.bz2 \
 "
 
 inherit module-base

--- a/yocto/libreswitch/meta-distro-libreswitch/recipes-asic/opennsl/opennsl-odp_3.1.0.12.bb
+++ b/yocto/libreswitch/meta-distro-libreswitch/recipes-asic/opennsl/opennsl-odp_3.1.0.12.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://packages/cdp/docs/LICENSE_CDP_BIN;md5=e4111c2d8b944da
 # Point by default to some http server where the file is hosted, even if doesn't exists
 # Using the local file by default causes bitbake to warn againts the inability to find the
 # file during the parsing stage
-SRC_URI += "https://archive.openswitch.net/opennsl/opennsl-${PV}-odp.tar.bz2;name=opennsl"
+SRC_URI += "https://libreswitch.org/opennsl/opennsl-${PV}-odp.tar.bz2;name=opennsl"
 # Use this SRC_URI if you put the tarball on the local download directory
 #SRC_URI += "file://${DL_DIR}/opennsl-${PV}-odp.tar.bz2;name=opennsl"
 


### PR DESCRIPTION
Move from:
https://archive.openswitch.net/opennsl
to:
https://libreswitch.org/opennsl
Content of packages is not changed.

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>