### PR TITLE
Correct ops-cli lib dependencies.

### DIFF
--- a/yocto/libreswitch/meta-distro-libreswitch/recipes-ops/mgmt/ops-cli.bb
+++ b/yocto/libreswitch/meta-distro-libreswitch/recipes-ops/mgmt/ops-cli.bb
@@ -3,7 +3,7 @@ LICENSE = "GPL-2.0 & LGPL-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=81bcece21748c91ba9992349a91ec11d\
                     file://COPYING.LIB;md5=01ef24401ded36cd8e5d18bfe947240c"
 
-DEPENDS = "ops-utils ops-ovsdb ops-rbac"
+DEPENDS = "ops-utils ops-ovsdb ops-rbac libcap"
 
 BRANCH ?= "${LBS_REPO_BRANCH}"
 


### PR DESCRIPTION
WARNING: ops-cli-gitAUTOINC do_package_qa: QA Issue:
ops-cli rdepends on libcap, but it isn't a build dependency, missing
libcap in DEPENDS or PACKAGECONFIG? [build-deps]

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>